### PR TITLE
Return correct playback position

### DIFF
--- a/mpDris2
+++ b/mpDris2
@@ -354,7 +354,7 @@ class MPRISRoot(dbus.service.Object):
         status = mpd_wrapper.status()
         if 'time' in status:
             current, end = status['time'].split(':')
-            return int(current) * 1000
+            return int(current) * 1000000
         else:
             return 0
 


### PR DESCRIPTION
With latest g-s-e-mediaplayer-git, restarting Shell during playback would cause the seekbar in media player indicator to restart at 0. It seems that mpDris2 returns too small Position.
