### PR TITLE
Minor source code cleanups

### DIFF
--- a/mpDris2
+++ b/mpDris2
@@ -74,15 +74,6 @@ allowed_tags = {
     'xesam:userRating': float,
 }
 
-# MPRIS capabilites
-CAN_GO_NEXT           = 1 << 0
-CAN_GO_PREV           = 1 << 1
-CAN_PAUSE             = 1 << 2
-CAN_PLAY              = 1 << 3
-CAN_SEEK              = 1 << 4
-CAN_PROVIDE_METADATA  = 1 << 5
-CAN_HAS_TRACKLIST     = 1 << 6
-
 # python dbus bindings don't include annotations and properties
 MPRIS2_INTROSPECTION = \
 """<node name="/org/mpris/MediaPlayer2">


### PR DESCRIPTION
- Removed MPRIS v1 capability constants, this program is v2-only;
- More consistent and PEP-8-like formatting of method declarations;
- Some other very subjective changes.
