### PR TITLE
Fix password@host parsing mixup

### DIFF
--- a/src/mpDris2
+++ b/src/mpDris2
@@ -787,7 +787,7 @@ if __name__ == '__main__':
             params['host'] = arg
 
     if '@' in params['host']:
-        params['host'], params['password'] = params['host'].split('@')
+        params['password'], params['host'] = params['host'].split('@', 1)
 
     if path:
         logger.info('Using %s as music library path' % path)


### PR DESCRIPTION
Changes in f0c14b5 caused MPD_HOST to be parsed as _host@password_.
