### PR TITLE
build: honor $NOCONFIGURE, correctly forward arguments otherwise

### DIFF
--- a/README
+++ b/README
@@ -9,6 +9,7 @@ mpDris2 is run in the user session and monitors a local or distant mpd server.
   git clone git://github.com/eonpatapon/mpDris2.git
   cd mpDris2
   ./autogen.sh
+  ./configure --sysconfdir=/etc
   make install (as root)
 
 Logout/login from your session.

--- a/autogen.sh
+++ b/autogen.sh
@@ -1,4 +1,7 @@
 #!/bin/sh
 
 autoreconf -fi
-./configure --sysconfdir=/etc $@
+
+if [ -z "$NOCONFIGURE" ]; then
+	./configure --sysconfdir=/etc "$@"
+fi


### PR DESCRIPTION
- Conform to http://people.gnome.org/~walters/docs/build-api.txt by not running
  ./configure if `$NOCONFIGURE` is set. The same is done by `gnome-autogen.sh`.
- Properly quote `$@` to work with arguments containing spaces.
