### PR TITLE
Fix cover detection & multiple artists (for #29)

### DIFF
--- a/src/mpDris2.in
+++ b/src/mpDris2.in
@@ -321,7 +321,7 @@ class MPDWrapper(mpd.MPDClient):
                             title = metadata['xesam:title']
                         artist = 'Unknown Artist'
                         if 'xesam:artist' in metadata:
-                            artist = metadata['xesam:artist'][0]
+                            artist = ", ".join(metadata['xesam:artist'])
                         notification.notify(title, _('by %s') % artist, uri)
 
                 if (abs(self._position - old_position) > 2 and \


### PR DESCRIPTION
This fixes the TypeError in latest cover detection code – `str.startswith` and `str.endswith` both require a tuple instead of a list:

```
  File "mpDris2", line 708, in format_metadata
    if f.startswith(covers_names) and f.endswith(covers_exts):
TypeError: startswith first arg must be str, unicode, or tuple, not list
```

Also, makes mpDris2 deal correctly with multiple artists and composers.
