### PR TITLE
Automatically exit when another instance is launched

### DIFF
--- a/src/mpDris2.in
+++ b/src/mpDris2.in
@@ -594,14 +594,35 @@ class MPRISInterface(dbus.service.Object):
         dbus.service.Object.__init__(self, dbus.SessionBus(),
                                      MPRISInterface.__path)
         self.path = path
+
+        self._bus = dbus.SessionBus()
+        self._uname = self._bus.get_unique_name()
+        self._dbus_obj = self._bus.get_object("org.freedesktop.DBus",
+                                              "/org/freedesktop/DBus")
+        self._dbus_obj.connect_to_signal("NameOwnerChanged",
+                                         self._name_owner_changed_callback,
+                                         arg0=self.__name)
+
         self.acquire_name()
+
+    def _name_owner_changed_callback(self, name, old_owner, new_owner):
+        if name == self.__name and old_owner == self._uname and new_owner != "":
+            try:
+                pid = self._dbus_obj.GetConnectionUnixProcessID(new_owner)
+            except:
+                pid = None
+            logger.info("Replaced by %s (PID %s)" % (new_owner, pid or "unknown"))
+            loop.quit()
 
     def acquire_name(self):
         self._bus_name = dbus.service.BusName(MPRISInterface.__name,
-                                              bus=dbus.SessionBus())
+                                              bus=self._bus,
+                                              allow_replacement=True,
+                                              replace_existing=True)
 
     def release_name(self):
-        del self._bus_name
+        if hasattr(self, "_bus_name"):
+            del self._bus_name
 
     __root_interface = "org.mpris.MediaPlayer2"
     __root_props = {


### PR DESCRIPTION
When multiple mpDris instances are running, only one can hold the `org.mpris.MediaPlayer2.mpd` bus name and send signals / receive method calls.

There are several possibilities:
1. Do not queue for ownership, but fail immediately if another process owns the name. This can be achieved by just setting `do_not_queue=True` in the `dbus.service.BusName()` constructor.
2. Ask DBus to replace the old owner, and allow being replaced. Exit upon receiving the "name lost" signal.

This pull-request implements approach #2, which seems to be more useful. (Unfortunately, it is unable to replace _older_ versions, but if necessary it could kill the old process by PID.)
