### PR TITLE
Re-register media keys when gnome-settings-daemon is restarted

### DIFF
--- a/src/mpDris2.in
+++ b/src/mpDris2.in
@@ -225,20 +225,9 @@ class MPDWrapper(mpd.MPDClient):
         self._position = 0
         self._time = 0
 
-        # init mmkeys, if configured
+        self._bus = dbus.SessionBus()
         if self._params['mmkeys']:
-            try:
-                gsd_object = dbus.SessionBus().get_object('org.gnome.SettingsDaemon',
-                                                          '/org/gnome/SettingsDaemon/MediaKeys')
-                # this is what gives us the multi media keys.
-                gsd_object.GrabMediaPlayerKeys('mpDris2', 0,
-                                               dbus_interface='org.gnome.SettingsDaemon.MediaKeys')
-                # connect_to_signal registers our callback function.
-                gsd_object.connect_to_signal('MediaPlayerKeyPressed', self.mediakey_callback)
-            except:
-                logger.error('Failed to connect to GNOME Settings Daemon.'
-                             ' Disabling multimedia key support')
-                params['mmkeys'] = False
+            self.setup_mediakeys()
 
     def run(self):
         """
@@ -379,7 +368,7 @@ class MPDWrapper(mpd.MPDClient):
         else:
             return False
 
-    # Events
+    ## Events
 
     def timer_callback(self):
         try:
@@ -509,6 +498,39 @@ class MPDWrapper(mpd.MPDClient):
                 or old_status.get('single', 0) != new_status.get('single', 0)):
             self._dbus_service.update_property('org.mpris.MediaPlayer2.Player',
                                                'LoopStatus')
+
+    ## Media keys
+
+    def setup_mediakeys(self):
+            self.register_mediakeys()
+            self._dbus_obj = self._bus.get_object("org.freedesktop.DBus",
+                                                  "/org/freedesktop/DBus")
+            self._dbus_obj.connect_to_signal("NameOwnerChanged",
+                                             self.gsd_name_owner_changed_callback,
+                                             arg0="org.gnome.SettingsDaemon")
+
+    def register_mediakeys(self):
+        try:
+            gsd_object = self._bus.get_object("org.gnome.SettingsDaemon",
+                                              "/org/gnome/SettingsDaemon/MediaKeys")
+            gsd_object.GrabMediaPlayerKeys("mpDris2", 0,
+                                           dbus_interface="org.gnome.SettingsDaemon.MediaKeys")
+        except:
+            logger.warning("Failed to connect to GNOME Settings Daemon. Media keys won't work.")
+        else:
+            self._bus.remove_signal_receiver(self.mediakey_callback)
+            gsd_object.connect_to_signal("MediaPlayerKeyPressed", self.mediakey_callback)
+
+    def gsd_name_owner_changed_callback(self, bus_name, old_owner, new_owner):
+        if bus_name == "org.gnome.SettingsDaemon" and new_owner != "":
+            def reregister():
+                logger.debug("Re-registering with GNOME Settings Daemon (owner %s)" % new_owner)
+                self.register_mediakeys()
+                return False
+            # Timeout is necessary since g-s-d takes some time to load all plugins.
+            gobject.timeout_add(600, reregister)
+
+    ## Compatibility functions
 
     # Fedora 17 still has python-mpd 0.2, which lacks fileno().
     if not hasattr(mpd.MPDClient, "fileno"):


### PR DESCRIPTION
This will re-register the media key handler with GNOME Settings Daemon when the latter is restarted (I do a lot of GNOME-crashing myself), or if Settings Daemon simply starts later than mpDris2 does (e.g. for people who launch mpd/mpDris2 first in their .xinitrc scripts).
