### PR TITLE
Ported to Python 3

### DIFF
--- a/src/mpDris2.in
+++ b/src/mpDris2.in
@@ -678,7 +678,10 @@ class MPDWrapper(object):
     ## Compatibility functions
 
     # Fedora 17 still has python-mpd 0.2, which lacks fileno().
-    if not hasattr(mpd.MPDClient, "fileno"):
+    if hasattr(mpd.MPDClient, "fileno"):
+        def fileno(self):
+            return self.client.fileno()
+    else:
         def fileno(self):
             if self.client._sock is None:
                 raise mpd.ConnectionError("Not connected")


### PR DESCRIPTION
This makes mpDris2 work with Python 3 while retaining backwards compatibility with Python2.
- The largest change is that `MPDWrapper` does not extend MPDClient directly anymore – wrapping the MPD commands has become almost impossible with the latest python-mpd. Instead of having three different overrides for _execute or _docommand, it just forwards the calls to `self.client` now.
