### PR TITLE
mpDris.in: Fix overlow in title length

### DIFF
--- a/src/mpDris2.in
+++ b/src/mpDris2.in
@@ -77,7 +77,7 @@ notification = None
 # MPRIS allowed metadata tags
 allowed_tags = {
     'mpris:trackid': dbus.ObjectPath,
-    'mpris:length': int,
+    'mpris:length': dbus.Int64,
     'mpris:artUrl': str,
     'xesam:album': str,
     'xesam:albumArtist': list,


### PR DESCRIPTION
According to the mpris spec 'mpris:length' should be an int64.
Pythons int type is casted to the dbus int32 type, which does overflow if the current track is greater than ~ 1h 12min
