### PR TITLE
Set transient hint in notifications

### DIFF
--- a/src/mpDris2.in
+++ b/src/mpDris2.in
@@ -758,6 +758,7 @@ class Notify:
         if self._notification:
             self._notification = pynotify.Notification(title, body, uri)
             self._notification.set_hint('desktop-entry', 'mpdris2')
+            self._notification.set_hint('transient', True)
             self._notification.show()
 
     def rnotify(self, title, body, uri=''):


### PR DESCRIPTION
On [Debian bug #738887](https://bugs.debian.org/cgi-bin/bugreport.cgi?bug=738887), Hank Donnay writes:

> If mpDris2 is run in GNOME3 with notifications enabled, the
> notifications will stay in the Message Bar until dismissed.
> 
> The included patch should add the 'transient' hint to notifications, in
> line with the [GNOME Desktop Notifications Spec](https://developer.gnome.org/notification-spec/)

Here's his patch as a git commit.
