### PR TITLE
Use unicode instead of str for song urls

### DIFF
--- a/src/mpDris2.in.py
+++ b/src/mpDris2.in.py
@@ -118,7 +118,7 @@ allowed_tags = {
     'xesam:lyricist': str,
     'xesam:title': str,
     'xesam:trackNumber': int,
-    'xesam:url': str,
+    'xesam:url': unicode,
     'xesam:useCount': int,
     'xesam:userRating': float,
 }
@@ -560,9 +560,10 @@ class MPDWrapper(object):
                 self._metadata['xesam:album'] = mpd_meta['name']
 
         if 'file' in mpd_meta:
-            song_url = mpd_meta['file']
+            song_url = unicode(mpd_meta['file'], 'utf-8')
             if not any([song_url.startswith(prefix) for prefix in urlhandlers]):
-                song_url = os.path.join(params['music_dir'], song_url)
+                song_url = os.path.join(params['music_dir'],
+                        song_url)
             self._metadata['xesam:url'] = song_url
             cover = self.find_cover(song_url)
             if cover:

--- a/src/mpDris2.in.py
+++ b/src/mpDris2.in.py
@@ -36,9 +36,11 @@ import logging
 import gettext
 import time
 import tempfile
+import codecs
 
 __version__ = "@version@"
 __git_version__ = "@gitversion@"
+__py3__ = sys.version_info > (3,)
 
 try:
     import mutagen
@@ -118,10 +120,13 @@ allowed_tags = {
     'xesam:lyricist': str,
     'xesam:title': str,
     'xesam:trackNumber': int,
-    'xesam:url': unicode,
     'xesam:useCount': int,
     'xesam:userRating': float,
 }
+if __py3__:
+    allowed_tags['xesam:url'] = str
+else:
+    allowed_tags['xesam:url'] = unicode
 
 # python dbus bindings don't include annotations and properties
 MPRIS2_INTROSPECTION = """<node name="/org/mpris/MediaPlayer2">
@@ -560,7 +565,11 @@ class MPDWrapper(object):
                 self._metadata['xesam:album'] = mpd_meta['name']
 
         if 'file' in mpd_meta:
-            song_url = unicode(mpd_meta['file'], 'utf-8')
+            if __py3__:
+                song_url = mpd_meta['file']
+            else:
+                song_url = unicode(mpd_meta['file'], 'utf-8')
+
             if not any([song_url.startswith(prefix) for prefix in urlhandlers]):
                 song_url = os.path.join(params['music_dir'],
                         song_url)


### PR DESCRIPTION
This fixes a UnicodeDecodeError when handling non-ascii filenames or paths.

So far I haven't changed any of the other strings to unicode because they all seemed to process fine, but that might be a pull for another day.