### PR TITLE
Use new GSD.MediaKeys bus name

### DIFF
--- a/src/mpDris2.in.py
+++ b/src/mpDris2.in.py
@@ -794,8 +794,13 @@ class MPDWrapper(object):
 
     def register_mediakeys(self):
         try:
-            gsd_object = self._bus.get_object("org.gnome.SettingsDaemon",
-                                              "/org/gnome/SettingsDaemon/MediaKeys")
+            try:
+                gsd_object = self._bus.get_object("org.gnome.SettingsDaemon.MediaKeys",
+                                                  "/org/gnome/SettingsDaemon/MediaKeys")
+            except:
+                # Try older name.
+                gsd_object = self._bus.get_object("org.gnome.SettingsDaemon",
+                                                  "/org/gnome/SettingsDaemon/MediaKeys")
             gsd_object.GrabMediaPlayerKeys("mpDris2", 0,
                                            dbus_interface="org.gnome.SettingsDaemon.MediaKeys")
         except:


### PR DESCRIPTION
With Gnome 3.16, the old(?) name stopped working for me. This change
fixes the problem for me. I kept a fallback for the old name.