### PR TITLE
Make failure to update notifications non-fatal

### DIFF
--- a/src/mpDris2.in.py
+++ b/src/mpDris2.in.py
@@ -898,8 +898,11 @@ class NotifyWrapper(object):
 
     def notify(self, title, body, uri=''):
         if self._notification:
-            self._notification.update(title, body, uri)
-            self._notification.show()
+            try:
+                self._notification.update(title, body, uri)
+                self._notification.show()
+            except Exception as e:
+                logger.warning('Failed to update notification: %s' % e)
 
 
 class MPRISInterface(dbus.service.Object):


### PR DESCRIPTION
If mpDris2 is started with no implementation of o.fd.Notifications
available, it might as well gracefully continue to work without that
feature.

Bug-Debian: https://bugs.debian.org/830816
Signed-off-by: Simon McVittie <smcv@debian.org>