### PR TITLE
Update mpDris2.service.in

### DIFF
--- a/src/mpDris2.service.in
+++ b/src/mpDris2.service.in
@@ -2,6 +2,7 @@
 Description=mpDris2 - Music Player Daemon D-Bus bridge
 
 [Service]
+Restart=on-failure
 ExecStart=@bindir@/mpDris2
 BusName=org.mpris.MediaPlayer2.mpd
 


### PR DESCRIPTION
Add a Restart option to service file so service will continue to work after an executable's unsuccessful exit. Works fine for me.