### PR TITLE
Switch SafeConfgiParser to ConfigParser

### DIFF
--- a/src/mpDris2.in.py
+++ b/src/mpDris2.in.py
@@ -1364,7 +1364,7 @@ if __name__ == '__main__':
             params['port'] = os.environ['MPD_PORT']
 
     # Read configuration
-    config = configparser.SafeConfigParser()
+    config = configparser.ConfigParser()
     if config_file:
         with open(config_file) as fh:
             config.read(config_file)


### PR DESCRIPTION
According to deprecation warning alias SafeConfigParser replaced with class call ConfigParser.