### PR TITLE
Add optional systemd journal logging

### DIFF
--- a/src/org.mpris.MediaPlayer2.mpd.service.in
+++ b/src/org.mpris.MediaPlayer2.mpd.service.in
@@ -1,4 +1,4 @@
 [D-BUS Service]
 Name=org.mpris.MediaPlayer2.mpd
-Exec=@bindir@/mpDris2 --no-timestamps
+Exec=@bindir@/mpDris2 --use-journal
 SystemdService=mpDris2.service


### PR DESCRIPTION
The `-j` / `--use-journal` switch replaces `-n`, and tells mpDris2 to _attempt_ direct journal logging. (Requires the `systemd.journal` Python module.) The `--use-journal` argument is added to the invocation in the systemd unit file.

Regular `sys.stderr` log output is used by default, and as a fallback if journald logging setup fails.

The `-d` flag is compatible with either logging method, so `mpDris2 -j -d` will direct debug logging to the journal.