### PR TITLE
Implement __getattr__ via lambda expresion

### DIFF
--- a/src/mpDris2.in.py
+++ b/src/mpDris2.in.py
@@ -882,9 +882,7 @@ class MPDWrapper(object):
     def __getattr__(self, attr):
         if attr[0] == "_":
             raise AttributeError(attr)
-        def fn(*a, **kw):
-            return self.call(attr, *a, **kw)
-        return fn
+        return lambda *a, **kw: self.call(attr, *a, **kw)
 
     def call(self, command, *args):
         fn = getattr(self.client, command)


### PR DESCRIPTION
It's admittedly trivial and kind of pointless, but the `__getattr__` implementation for `MPDWrapper` defines a function `fn` (which does nothing but `return self.call(...)`), the immediately returns `fn` to its own caller.

Since it's never called by that name, `fn` is effectively an anonymous function. The whole thing can be done in one line with a `lambda` expression, instead of requiring three lines to implement.