### PR TITLE
Drop python2 support

### DIFF
--- a/src/mpDris2.in.py
+++ b/src/mpDris2.in.py
@@ -20,8 +20,7 @@
 # Some bits taken from quodlibet mpris plugin by <christoph.reiter@gmx.at>
 
 
-from __future__ import print_function
-
+from configparser import ConfigParser
 import os
 import sys
 import re
@@ -45,11 +44,6 @@ try:
     import mutagen
 except ImportError:
     mutagen = None
-
-try:
-    from configparser import ConfigParser
-except ImportError:
-    from ConfigParser import SafeConfigParser as ConfigParser
 
 try:
     import gi


### PR DESCRIPTION
The shebang already points to python3 so it doesn't make sense to have these compat shims in anyway.