### PR TITLE
find_cover: Account for non-dir directories

### DIFF
--- a/src/mpDris2.in.py
+++ b/src/mpDris2.in.py
@@ -667,7 +667,7 @@ class MPDWrapper(object):
                             return self._create_temp_cover(pic)
 
             # Look in song directory for common album cover files
-            if os.path.exists(song_dir):
+            if os.path.exists(song_dir) and os.path.isdir(song_dir):
                 for f in os.listdir(song_dir):
                     if self._params['cover_regex'].match(f):
                         return 'file://' + os.path.join(song_dir, f)


### PR DESCRIPTION
As I said on #135, find_cover does not account for non-dir music "directories", such as archive files (`.zip`s etc), and causes a crash. This PR fixes that behavior.

Fixes #135