### PR TITLE
configs: Give config file priority over envvars

### DIFF
--- a/src/mpDris2.in.py
+++ b/src/mpDris2.in.py
@@ -1386,19 +1386,12 @@ if __name__ == '__main__':
 
     logger.addHandler(log_handler)
 
-    # Pick up the server address (argv -> environment -> config)
+    # Pick up the server address (argv -> config -> environment)
     for arg in args[:2]:
         if arg.isdigit():
             params['port'] = arg
         else:
             params['host'] = arg
-
-    if not params['host']:
-        if 'MPD_HOST' in os.environ:
-            params['host'] = os.environ['MPD_HOST']
-    if not params['port']:
-        if 'MPD_PORT' in os.environ:
-            params['port'] = os.environ['MPD_PORT']
 
     # Read configuration
     config = ConfigParser()
@@ -1417,8 +1410,20 @@ if __name__ == '__main__':
             else:
                 params[p] = defaults[p]
 
+    # Use environment variables as a last-ditch fallback
+    if not params['host']:
+        if 'MPD_HOST' in os.environ:
+            params['host'] = os.environ['MPD_HOST']
+    if not params['port']:
+        if 'MPD_PORT' in os.environ:
+            params['port'] = os.environ['MPD_PORT']
+
     if '@' in params['host']:
-        params['password'], params['host'] = params['host'].rsplit('@', 1)
+        host_password, params['host'] = params['host'].rsplit('@', 1)
+        if 'password' in params:
+            log.warning(
+                "'password@host' setting clobbered explicit password")
+        params['password'] = host_password
 
     params['host'] = os.path.expanduser(params['host'])
 


### PR DESCRIPTION
The previous configuration code gave the `MPD_HOST` and `MPD_PORT` environment variables priority over mpDris2's own config file, when it comes to settings. I feel that's backwards, especially for a daemon that runs with the user's environment, but _not_ interactively — whatever's set in its config file should trump the generic MPD environment variables, which make more sense as a last-resort fallback.

Also, because there's potential for the user to set a `password` (but not `host`) in their config file, but then have `MPD_HOST` set to a `password@host` string, the code will let the `MPD_HOST` password override the one from the config file (iff the host part is being used, because it was _not_ set by other means) — but it'll log a warning about it, to let the user know that the settings conflict caused some of their configs to be ignored/overridden.
