### PR TITLE
mpdris2.desktop: Disable if using systemd for session management

### DIFF
--- a/src/mpdris2.desktop
+++ b/src/mpdris2.desktop
@@ -9,3 +9,5 @@ Categories=Audio;Music;Player;AudioVideo;
 NoDisplay=true
 X-DBUS-ServiceName=org.mpris.MediaPlayer2.mpd
 X-GNOME-UsesNotifications=true
+X-systemd-skip=true
+X-GNOME-HiddenUnderSystemd=true


### PR DESCRIPTION
systemd-xdg-autostart-generator in systemd >= 246 would generate a
systemd unit from the XDG autostart file, but this package already has
a mpDris2.service, making app-mpdris2-autostart.service redundant.

Similarly, GNOME would normally take responsibility for launching
any XDG autostarted services that systemd doesn't, but that's redundant
with mpDris2.service.