### PR TITLE
Log to systemd journal when started via systemd

### DIFF
--- a/src/mpDris2.service.in
+++ b/src/mpDris2.service.in
@@ -3,7 +3,7 @@ Description=mpDris2 - Music Player Daemon D-Bus bridge
 
 [Service]
 Restart=on-failure
-ExecStart=@bindir@/mpDris2
+ExecStart=@bindir@/mpDris2 --use-journal
 BusName=org.mpris.MediaPlayer2.mpd
 
 [Install]


### PR DESCRIPTION
Commit d34b8821 only did this when started by the dbus-daemon using
traditional (non-systemd) activation, which seems odd when trying to
use a systemd-specific feature.