### PR TITLE
Metion that Mutagen is also needed for embedded cover art

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,8 +35,8 @@ To set a different host or port copy the example configuration file
 Use the configuration to enable notifications and multimedia keys support (on
 the GNOME desktop).
 
-You need also to set the ``music_dir`` option for mpDris2 to export covers
-paths in the MPRIS metadata.
+You need also to set the ``music_dir`` option and have the Python ``mutagen``
+module installed for mpDris2 to export covers paths in the MPRIS metadata.
 
 Restart your session or mpDris2 after changing mpDris2.conf.
 


### PR DESCRIPTION
It was not obvious to me that I needed to install an additional dependency for embedded cover art to work.

For context: I installed mpDris2 version 0.9.1 via `apt install mpdris2` on Pop!_OS 21.04. The `mpdris2` package did not list `python3-mutagen` as any sort of dependency. Although, `mpdris2` did recommend `gir1.2-notify-0.7` for sending track-change notifications.