### PR TITLE
Protect access to last_currentsong

### DIFF
--- a/src/mpDris2.in.py
+++ b/src/mpDris2.in.py
@@ -490,7 +490,9 @@ class MPDWrapper(object):
             self.notify_about_state('stop')
 
     def last_currentsong(self):
-        return self._currentsong.copy()
+        if self._currentsong:
+            return self._currentsong.copy()
+        return None
 
     @property
     def metadata(self):
@@ -502,8 +504,12 @@ class MPDWrapper(object):
         http://www.freedesktop.org/wiki/Specifications/mpris-spec/metadata
         """
 
-        mpd_meta = self.last_currentsong()
         self._metadata = {}
+
+        mpd_meta = self.last_currentsong()
+        if not mpd_meta:
+            logger.warning("Attempted to update metadata, but retrieved none")
+            return
 
         for tag in ('album', 'title'):
             if tag in mpd_meta:
@@ -1218,6 +1224,9 @@ class MPRISInterface(dbus.service.Object):
     @dbus.service.method(__player_interface, in_signature='ox', out_signature='')
     def SetPosition(self, trackid, position):
         song = mpd_wrapper.last_currentsong()
+        if not song:
+            logger.error("Failed to retrieve song position, can't seek")
+            return()
         # FIXME: use real dbus objects
         if str(trackid) != '/org/mpris/MediaPlayer2/Track/%s' % song['id']:
             return


### PR DESCRIPTION
I confess I'm not sure _when_ or _**how**_ it would happen, myself, but we received a [crashreporter log](https://bugzilla.redhat.com/show_bug.cgi?id=1963403) for the Fedora package indicating that the value of `self._currentsong` could in certain circumstances be a boolean value. (`False`, one presumes.):

```text
Version-Release number of selected component:
mpdris2-0.8-6.20200205git491588a.fc34

Additional info:
reporter:       libreport-2.14.0
cgroup:         0::/user.slice/user-1000.slice/user@1000.service/app.slice/app-gnome-mpdris2-47029.scope
cmdline:        /usr/bin/python3 /usr/bin/mpDris2
crash_function: last_currentsong
exception_type: AttributeError
executable:     /usr/bin/mpDris2
interpreter:    python3-3.9.5-2.fc34.x86_64
kernel:         5.11.21-300.fc34.x86_64
runlevel:       N 5
type:           Python3
uid:            1000

Truncated backtrace:
mpDris2:499:last_currentsong:AttributeError: 'bool' object has no attribute 'copy'

Traceback (most recent call last):
  File "/usr/lib/python3.9/site-packages/gi/overrides/GLib.py", line 671, in <lambda>
    func_fdtransform = lambda _, cond, *data: callback(channel, cond, *data)
  File "/usr/bin/mpDris2", line 475, in socket_callback
    self._update_properties(force=True)
  File "/usr/bin/mpDris2", line 761, in _update_properties
    self.update_metadata()
  File "/usr/bin/mpDris2", line 511, in update_metadata
    mpd_meta = self.last_currentsong()
  File "/usr/bin/mpDris2", line 499, in last_currentsong
    return self._currentsong.copy()
AttributeError: 'bool' object has no attribute 'copy'

Local variables in innermost frame:
self: <__main__.MPDWrapper object at 0x7fd8681c93a0>
```

(This was against 0.8 — I'm building packages of the latest version now — but there have been absolutely no changes in the source between 0.8 and the current `HEAD` that would affect this bug at all... if it was present, it's _still_ present.)

So, this PR protects all attempts to use the return from `self.last_currentsong()` with truthiness checks, and changes `last_currentsong()` itself to check that `self._currentsong` isn't `False`, before attempting to call its `copy()` method.
