### PR TITLE
Make class(es) more self-contained, reduce globals

### DIFF
--- a/src/mpDris2.in.py
+++ b/src/mpDris2.in.py
@@ -74,6 +74,9 @@ except ImportError:
 
 _ = gettext.gettext
 
+logger = logging.getLogger('mpDris2')
+logger.propagate = False
+
 identity = "Music Player Daemon"
 
 params = {
@@ -1367,8 +1370,6 @@ if __name__ == '__main__':
         usage(params)
         sys.exit()
 
-    logger = logging.getLogger('mpDris2')
-    logger.propagate = False
     logger.setLevel(log_level)
 
     # Attempt to configure systemd journal logging, if enabled

--- a/src/mpDris2.in.py
+++ b/src/mpDris2.in.py
@@ -250,7 +250,7 @@ class MPDWrapper(object):
         errors and similar
     """
 
-    def __init__(self, params):
+    def __init__(self, params, loop=None):
         self.client = mpd.MPDClient()
 
         self._dbus = dbus
@@ -281,6 +281,7 @@ class MPDWrapper(object):
         if self._params['mmkeys']:
             self.setup_mediakeys()
 
+        self._loop = loop
     def run(self):
         """
         Try to connect to MPD; retry every 5 seconds on failure.
@@ -995,7 +996,8 @@ class MPRISInterface(dbus.service.Object):
             except:
                 pid = None
             logger.info("Replaced by %s (PID %s)" % (new_owner, pid or "unknown"))
-            loop.quit()
+            if self._loop:
+                self._loop.quit()
 
     def acquire_name(self):
         self._bus_name = dbus.service.BusName(self._name,
@@ -1477,7 +1479,7 @@ if __name__ == '__main__':
     notification = NotifyWrapper(params)
 
     # Create wrapper to handle connection failures with MPD more gracefully
-    mpd_wrapper = MPDWrapper(params)
+    mpd_wrapper = MPDWrapper(params, loop=loop)
     mpd_wrapper.run()
 
     # Run idle loop


### PR DESCRIPTION
This PR contains a set of what I'm calling "quality of life" changes for the code. Nothing user-visible, this is all an attempt to make the `MPDWrapper` class and its helpers more self-contained, and importable/usable outside of the `mpDris2` source file itself — for testing/debugging purposes. The user should see absolutely no difference in normal operation.

Specifically, this PR eliminates all references from inside the class code to symbols that are only defined if the `if __name__== '__main__'` block is run. As a result, it's now possible to import the class into an interactive session and call methods on it by hand, without it crashing due to things like `mpd_wrapper` and `loop` being undefined, or `notification` not being callable because its value is `None`.

Specific changes (as separate commits):
1. Move logger _instantiation_ to top of module (the level is still configured in the `__main__`-only code)
2. Set up `notification` in the `MPDWrapper.__init__()` code as `self._notification`, since it's never used in the `__main__` code but all of the class code assumes it's been properly initialized
3. Still define `loop` only in the `__main__` code (I agree that's a good idea), but pass it in to the `MPDWrapper()` constructor and use `self._loop` to access it later.
4. Pass the `MPDWrapper` instance in to `MPRISInterface()` along with the `params`, and store it as `MPRISInterface.__wrapper`. Then, use that to make calls back to it, instead of trying to use `mpd_wrapper` which is undefined if the `__main__` code wasn't executed

With these changes, it's possible to debug the code interactively via the REPL (after running `ln -s mpDris2 mpDris2.py`), all that's required is to set up the `MainLoop` and create a `params` dictionary, then pass them both to `MPDWrapper()` thusly:
```python
>>> import mpDris2
>>> mpDris2.DBusGMainLoop(set_as_default=True); loop = mpDris2.GLib.MainLoop()
<dbus.mainloop.NativeMainLoop object at 0x7f6fc6a9e4f0>
>>> mpdw = mpDris2.MPDWrapper({'password': 'XXXXXXX', 'host': 'XXXXXXX', 'port': 6600,
... 'mmkeys': False, 'progname': 'mpdris2', 'bus_name': None, 'notify_urgency': 0,
... 'notify': True, 'cover_regex': None, 'music_dir': ''}, loop=loop)
>>> mpdw.my_connect()
False
>>> mpdw.connected
True
>>> status = mpdw.status()
>>> from pprint import pp
>>> pp(status)
{'volume': '58',
 'repeat': '0',
 'random': '0',
 'single': '0',
 'consume': '0',
 'partition': 'default',
 'playlist': '8',
 'playlistlength': '6',
 'mixrampdb': '0',
 'state': 'play',
 'xfade': '4',
 'song': '2',
 'songid': '3',
 'time': '4:2354',
 'elapsed': '3.995',
 'bitrate': '192',
 'duration': '2353.848',
 'audio': '48000:24:2',
 'nextsong': '3',
 'nextsongid': '4'}
>>> mpdw.pause()
```
(...and it does.)
