### PR TITLE
Add optional CD-like previous behavior

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,3 +50,4 @@ Restart your session or mpDris2 after changing mpDris2.conf.
     [Bling]
     notify = False
     mmkeys = True
+    cdprev = True

--- a/src/mpDris2.conf
+++ b/src/mpDris2.conf
@@ -16,3 +16,5 @@
 #notify = True
 # Urgency of the notification: 0 for low, 1 for medium and 2 for high.
 #notify_urgency = 0
+# CD-like previous command: if playback is past 3 seconds, seek to the beginning
+#cdprev = True

--- a/src/mpDris2.in.py
+++ b/src/mpDris2.in.py
@@ -70,6 +70,7 @@ params = {
     'mmkeys': True,
     'notify': (Notify is not None),
     'notify_urgency': 0,
+    'cdprev': False,
 }
 
 defaults = {
@@ -872,6 +873,12 @@ class MPDWrapper(object):
             raise AttributeError(attr)
         return lambda *a, **kw: self.call(attr, *a, **kw)
 
+    def previous(self):
+        if self._params['cdprev'] and self._position >= 3:
+            self.seekid(int(self._status['songid']), 0)
+        else:
+            self.call("previous")
+
     def call(self, command, *args):
         fn = getattr(self.client, command)
         try:
@@ -1408,7 +1415,7 @@ if __name__ == '__main__':
 
     params['host'] = os.path.expanduser(params['host'])
 
-    for p in ['mmkeys', 'notify']:
+    for p in ['mmkeys', 'notify', 'cdprev']:
         if config.has_option('Bling', p):
             params[p] = config.getboolean('Bling', p)
 


### PR DESCRIPTION
This adds a "cdprev" config option which makes the previous command behave more like most other music players: if playback is more than three seconds into a track, seek to the beginning, otherwise go to the previous track.

This option is named after a similar feature in mpc.