### PR TITLE
Add mp4 cover art support

### DIFF
--- a/src/mpDris2.in.py
+++ b/src/mpDris2.in.py
@@ -658,6 +658,16 @@ class MPDWrapper(object):
                         if pic.type == mutagen.id3.PictureType.COVER_FRONT:
                             self._temp_song_url = song_url
                             return self._create_temp_cover(pic)
+                elif song.tags and "covr" in song.tags:
+                    # MP4
+                    for data in song.get("covr", []):
+                        mimes = {mutagen.mp4.AtomDataType.JPEG: "image/jpeg",
+                                 mutagen.mp4.AtomDataType.PNG: "image/png"}
+
+                        pic = mutagen.id3.APIC(mime=mimes.get(data.imageformat, ""), data=data)
+
+                        self._temp_song_url = song_url
+                        return self._create_temp_cover(pic)
 
             # Look in song directory for common album cover files
             if os.path.exists(song_dir) and os.path.isdir(song_dir):


### PR DESCRIPTION
This PR adds MP4 cover art support based on the mutagen docs for MP4 tags. It assumes the first cover art (if any) is the front cover and instantiates its own `mutagen.id3.APIC` since the MP4 API doesn't provide one and `_create_temp_cover` expects one

Let me know if anything is problematic or should be changed!