### PR TITLE
Add mopidy local url cover art support

### DIFF
--- a/src/mpDris2.in.py
+++ b/src/mpDris2.in.py
@@ -37,6 +37,7 @@ import socket
 import sys
 import tempfile
 import time
+import urllib.parse
 
 try:
     import mutagen
@@ -608,81 +609,87 @@ class MPDWrapper(object):
     def find_cover(self, song_url):
         if song_url.startswith('file://'):
             song_path = song_url[7:]
-            song_dir = os.path.dirname(song_path)
+        elif song_url.startswith('local:track:') and self._params['music_dir'].startswith('file://'):
+            song_path = os.path.join(self._params['music_dir'][7:], urllib.parse.unquote(song_url[12:]))
+        else:
+            return None
 
-            # Try existing temporary file
-            if self._temp_cover:
-                if song_url == self._temp_song_url:
-                    logger.debug("find_cover: Reusing old image at %r" % self._temp_cover.name)
-                    return 'file://' + self._temp_cover.name
-                else:
-                    logger.debug("find_cover: Cleaning up old image at %r" % self._temp_cover.name)
-                    self._temp_song_url = None
-                    self._temp_cover.close()
+        song_dir = os.path.dirname(song_path)
 
-            # Search for embedded cover art
-            song = None
-            if mutagen and os.path.exists(song_path):
-                try:
-                    song = mutagen.File(song_path)
-                except mutagen.MutagenError as e:
-                    logger.error("Can't extract covers from %r: %r" % (song_path, e))
-            if song is not None:
-                if hasattr(song, "pictures"):
-                    # FLAC
-                    for pic in song.pictures:
-                        if pic.type == mutagen.id3.PictureType.COVER_FRONT:
-                            self._temp_song_url = song_url
-                            return self._create_temp_cover(pic)
-                if song.tags:
-                    # present but null for some file types
-                    for tag in song.tags.keys():
-                        if tag.startswith("APIC:"):
-                            for pic in song.tags.getall(tag):
-                                if pic.type == mutagen.id3.PictureType.COVER_FRONT:
-                                     self._temp_song_url = song_url
-                                     return self._create_temp_cover(pic)
-                        elif tag == "metadata_block_picture":
-                            # OGG
-                            for b64_data in song.get(tag, []):
-                                try:
-                                    data = base64.b64decode(b64_data)
-                                except (TypeError, ValueError):
-                                    continue
+        # Try existing temporary file
+        if self._temp_cover:
+            if song_url == self._temp_song_url:
+                logger.debug("find_cover: Reusing old image at %r" % self._temp_cover.name)
+                return 'file://' + self._temp_cover.name
+            else:
+                logger.debug("find_cover: Cleaning up old image at %r" % self._temp_cover.name)
+                self._temp_song_url = None
+                self._temp_cover.close()
 
-                                try:
-                                    pic = mutagen.flac.Picture(data)
-                                except mutagen.flac.error:
-                                    continue
-
-                                if pic.type == mutagen.id3.PictureType.COVER_FRONT:
-                                    self._temp_song_url = song_url
-                                    return self._create_temp_cover(pic)
-                        elif tag == "covr":
-                            # MP4
-                            for data in song.get(tag, []):
-                                mimes = {mutagen.mp4.AtomDataType.JPEG: "image/jpeg",
-                                         mutagen.mp4.AtomDataType.PNG: "image/png"}
-
-                                pic = mutagen.id3.APIC(mime=mimes.get(data.imageformat, ""), data=data)
-
+        # Search for embedded cover art
+        song = None
+        if mutagen and os.path.exists(song_path):
+            try:
+                song = mutagen.File(song_path)
+            except mutagen.MutagenError as e:
+                logger.error("Can't extract covers from %r: %r" % (song_path, e))
+        if song is not None:
+            if hasattr(song, "pictures"):
+                # FLAC
+                for pic in song.pictures:
+                    if pic.type == mutagen.id3.PictureType.COVER_FRONT:
+                        self._temp_song_url = song_url
+                        return self._create_temp_cover(pic)
+            if song.tags:
+                # present but null for some file types
+                for tag in song.tags.keys():
+                    if tag.startswith("APIC:"):
+                        for pic in song.tags.getall(tag):
+                            if pic.type == mutagen.id3.PictureType.COVER_FRONT:
                                 self._temp_song_url = song_url
                                 return self._create_temp_cover(pic)
+                    elif tag == "metadata_block_picture":
+                        # OGG
+                        for b64_data in song.get(tag, []):
+                            try:
+                                data = base64.b64decode(b64_data)
+                            except (TypeError, ValueError):
+                                continue
 
-            # Look in song directory for common album cover files
-            if os.path.exists(song_dir) and os.path.isdir(song_dir):
-                for f in os.listdir(song_dir):
-                    if self._params['cover_regex'].match(f):
-                        return 'file://' + os.path.join(song_dir, f)
+                            try:
+                                pic = mutagen.flac.Picture(data)
+                            except mutagen.flac.error:
+                                continue
 
-            # Search the shared cover directories
-            if 'xesam:artist' in self._metadata and 'xesam:album' in self._metadata:
-                artist = ",".join(self._metadata['xesam:artist'])
-                album = self._metadata['xesam:album']
-                for template in downloaded_covers:
-                    f = os.path.expanduser(template % (artist, album))
-                    if os.path.exists(f):
-                        return 'file://' + f
+                            if pic.type == mutagen.id3.PictureType.COVER_FRONT:
+                                self._temp_song_url = song_url
+                                return self._create_temp_cover(pic)
+                    elif tag == "covr":
+                        # MP4
+                        for data in song.get(tag, []):
+                            mimes = {mutagen.mp4.AtomDataType.JPEG: "image/jpeg",
+                                     mutagen.mp4.AtomDataType.PNG: "image/png"}
+
+                            pic = mutagen.id3.APIC(mime=mimes.get(data.imageformat, ""), data=data)
+
+                            self._temp_song_url = song_url
+                            return self._create_temp_cover(pic)
+
+        # Look in song directory for common album cover files
+        if os.path.exists(song_dir) and os.path.isdir(song_dir):
+            for f in os.listdir(song_dir):
+                if self._params['cover_regex'].match(f):
+                    return 'file://' + os.path.join(song_dir, f)
+
+        # Search the shared cover directories
+        if 'xesam:artist' in self._metadata and 'xesam:album' in self._metadata:
+            artist = ",".join(self._metadata['xesam:artist'])
+            album = self._metadata['xesam:album']
+            for template in downloaded_covers:
+                f = os.path.expanduser(template % (artist, album))
+                if os.path.exists(f):
+                    return 'file://' + f
+
         return None
 
     def _create_temp_cover(self, pic):


### PR DESCRIPTION
This PR adds support for finding cover art based on `music_dir` when using the local plugin from Mopidy. Only the first few lines of the diff matter, which parse the `local:track:[path/relative/to/music_dir.ext]` URL format that plugin gives over MPD metadata and prepends it with the configured `music_dir`

The rest of the diff de-indents everything else in the `find_cover` method since it now parses `song_path` early and returns if that fails (which allows for other adaptations to be made later, if for some reason that's necessary)

It works great in my testing with the rest of mpDris2 and this was my last local patch I have been running it with. Let me know if anything needs to be changed. Thank you all for this handy bit of software!