### PR TITLE
Add many new options for notifications

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,5 +49,14 @@ Restart your session or mpDris2 after changing mpDris2.conf.
 
     [Bling]
     notify = False
+    notify_paused = True
     mmkeys = True
     cdprev = True
+
+    [Notify]
+    urgency = 0
+    timeout = -1
+    summary =
+    body =
+    paused_summary =
+    paused_body =

--- a/src/mpDris2.conf
+++ b/src/mpDris2.conf
@@ -14,7 +14,23 @@
 [Bling]
 #mmkeys = True
 #notify = True
-# Urgency of the notification: 0 for low, 1 for medium and 2 for high.
-#notify_urgency = 0
+# Send notifications while paused?
+#notify_paused = True
 # CD-like previous command: if playback is past 3 seconds, seek to the beginning
 #cdprev = True
+
+[Notify]
+# Urgency of the notification: 0 for low, 1 for medium and 2 for high.
+#urgency = 0
+# Timeout of the notification in milliseconds. -1 uses the notification's default
+# and 0 sets the notification to never timeout.
+#timeout = -1
+# Format the notification's summary and body in either playing or paused state.
+# Leave blank to use mpDris2's internal defaults.
+# Possible values:
+#     %album%, %title%, %id%, %time%, %timeposition%, %date%, %track%,
+#     %disc%, %artist%, %albumartist%, %composer%, %genre%, %file%
+#summary =
+#body =
+#paused_summary =
+#paused_body =


### PR DESCRIPTION
This primarily adds the ability to format the notification's summary and
body for either the paused or playing states. Additionally, an option to
enable/disable notifications when the player is paused and an option for
notification timeout have been added.

~~The only remaining issue I have is that the format strings are in the style of `%%...%%` instead of mimicking `mpc`'s style of `%...%`. From what I've gathered, I'd need to disable interpolation in `ConfigParser()` but doing so removes the convenience of  detecting subsections. I'm not sure if what I have currently is good enough or if it's worth the trouble of trying to extract the values without interpolation.~~

Well that turned out easy.

This PR mostly implements https://github.com/eonpatapon/mpDris2/issues/148