### PR TITLE
Add pause icon option

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,6 +50,7 @@ Restart your session or mpDris2 after changing mpDris2.conf.
     [Bling]
     notify = False
     notify_paused = True
+    pause_icon = media-playback-pause-symbolic
     mmkeys = True
     cdprev = True
 

--- a/src/mpDris2.conf
+++ b/src/mpDris2.conf
@@ -16,6 +16,8 @@
 #notify = True
 # Send notifications while paused?
 #notify_paused = True
+# Notification icon when pausing. Leave empty to use album cover.
+#pause_icon = media-playback-pause-symbolic
 # CD-like previous command: if playback is past 3 seconds, seek to the beginning
 #cdprev = True
 

--- a/src/mpDris2.in.py
+++ b/src/mpDris2.in.py
@@ -71,6 +71,7 @@ params = {
     'mmkeys': True,
     'notify': (Notify is not None),
     "notify_paused": False,
+    "pause_icon": "media-playback-pause-symbolic",
     "cdprev": False,
     # Notify
     "summary": "",
@@ -643,7 +644,7 @@ class MPDWrapper(object):
         if state == "pause":
             if not self._params["notify_paused"]:
                 return
-            uri = "media-playback-pause-symbolic"
+            uri = self._params["pause_icon"] or uri
 
             if self._params["paused_summary"]:
                 title = self.format_notification(meta, self._params["paused_summary"])
@@ -1489,6 +1490,9 @@ if __name__ == '__main__':
     for p in ["mmkeys", "notify", "notify_paused", "cdprev"]:
         if config.has_option("Bling", p):
             params[p] = config.getboolean("Bling", p)
+
+    if config.has_option("Bling", "pause_icon"):
+        params["pause_icon"] = config.get("Bling", "pause_icon")
 
     if config.has_option("Notify", "summary"):
         params["summary"] = config.get("Notify", "summary", raw=True)


### PR DESCRIPTION
Adds a config option `pause_icon` under Bling to change the pause notification icon. If `pause_icon` is the empty string, it will use the album cover.