### PR TITLE
Add --managed option to disable timer

### DIFF
--- a/src/mpDris2.service.in
+++ b/src/mpDris2.service.in
@@ -1,11 +1,12 @@
 [Unit]
 Description=mpDris2 - Music Player Daemon D-Bus bridge
+After=mpd.service
+BindsTo=mpd.service
 
 [Service]
 Restart=on-failure
-ExecStart=@bindir@/mpDris2 --use-journal
+ExecStart=@bindir@/mpDris2 --use-journal --no-reconnect
 BusName=org.mpris.MediaPlayer2.mpd
 
 [Install]
-WantedBy=default.target
-# WantedBy=daemon.target
+WantedBy=mpd.service


### PR DESCRIPTION
When idle is available, the main purpose of the timer loop is to reconnect the
socket when it is disconnected.

An alternative is to allow systemd to handle this for us. We can bind the daemon
to the mpd service, so that it is started automatically with the mpd service.

Add a new command-line option `--managed`. If this is set, the daemon will exit
cleanly instead of attempting a reconnect loop, under the assmption that systemd
will restart it when mpd is available again.

Fixes #120
Also fixes #160 when managed by systemd - the service is only started when MPD is
Improves #133 when using systemd - the timer is no longer enabled