### PR TITLE
Add mpDris2-remote.service, --abort-on-disconnect flag

### DIFF
--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -8,16 +8,18 @@ dist_desktop_DATA = mpdris2.desktop
 autostart_DATA = mpdris2.desktop
 dist_doc_DATA = mpDris2.conf
 nodist_dbus_DATA = org.mpris.MediaPlayer2.mpd.service
-nodist_systemd_user_DATA = mpDris2.service
+nodist_systemd_user_DATA = mpDris2.service mpDris2-remote.service
 
 EXTRA_DIST = \
 	org.mpris.MediaPlayer2.mpd.service.in \
 	mpDris2.service.in \
+	mpDris2-remote.service.in \
 	mpDris2.in.py
 
 CLEANFILES = \
 	org.mpris.MediaPlayer2.mpd.service \
 	mpDris2.service \
+	mpDris2-remote.service \
 	mpDris2
 
 edit = sed -e 's|@bindir[@]|$(bindir)|g' \
@@ -29,8 +31,6 @@ mpDris2: mpDris2.in.py Makefile
 	$(AM_V_GEN) $(edit) $< > $@.tmp && mv $@.tmp $@
 	$(AM_V_at) chmod a+x $@
 
-org.mpris.MediaPlayer2.mpd.service: org.mpris.MediaPlayer2.mpd.service.in Makefile
+%.service: %.service.in Makefile
 	$(AM_V_GEN) $(edit) $< > $@.tmp && mv $@.tmp $@
 
-mpDris2.service: mpDris2.service.in Makefile
-	$(AM_V_GEN) $(edit) $< > $@.tmp && mv $@.tmp $@

--- a/src/mpDris2-remote.service.in
+++ b/src/mpDris2-remote.service.in
@@ -1,12 +1,14 @@
 [Unit]
 Description=mpDris2 - Music Player Daemon D-Bus bridge
-After=mpd.service
-BindsTo=mpd.service
+Conflicts=mpDris2.service
 
 [Service]
 Restart=on-failure
-ExecStart=@bindir@/mpDris2 --use-journal --no-reconnect
+RestartSec=5
+RestartMaxDelaySec=15min
+RestartSteps=20
+ExecStart=@bindir@/mpDris2 --use-journal --no-reconnect --abort-on-disconnect
 BusName=org.mpris.MediaPlayer2.mpd
 
 [Install]
-WantedBy=mpd.service
+WantedBy=default.target

--- a/src/mpDris2.in.py
+++ b/src/mpDris2.in.py
@@ -273,11 +273,16 @@ class MPDWrapper(object):
 
     def run(self):
         """
-        Try to connect to MPD; retry every 5 seconds on failure.
+        Try to connect to MPD
         """
         if self.my_connect():
-            GLib.timeout_add_seconds(5, self.my_connect)
-            return False
+            if self._should_reconnect:
+                GLib.timeout_add_seconds(5, self.my_connect)
+                return False
+            else:
+                logger.debug("Initial connect failed. Not retrying.")
+                loop.quit()
+                sys.exit(self._disconnect_exit_code)
         else:
             return True
 

--- a/src/mpDris2.service.in
+++ b/src/mpDris2.service.in
@@ -2,6 +2,7 @@
 Description=mpDris2 - Music Player Daemon D-Bus bridge
 After=mpd.service
 BindsTo=mpd.service
+Conflicts=mpDris2-remote.service
 
 [Service]
 Restart=on-failure


### PR DESCRIPTION
This PR implements the second service definition I described in https://github.com/eonpatapon/mpDris2/pull/161#issuecomment-2567144797, for systems which use an `mpd` daemon that isn't running on the same system as the mpDris2 client.

For those systems, a systemd service file `mpDris2-remote.service` is added to the installation, as an alternative to `mpDris2.service`. (The two services are set to conflict, so that one or the other must be used, but not both.)

A new flag, `--abort-on-disconnect`, is added to the mpDris2 daemon, and used in the `mpDris2-remote.service` to have mpDris2 exit _uncleanly_ when a connection failure occurs. Without it, the exits will be clean exits (intended for `mpDris2.service`).

The `--no-reconnect` logic is also extended to the initial connection attempt, so that initial startups will not retry when `--no-reconnect` is set (with or without `--abort-on-disconnect`).

### Other changes

A separate commit updates the Makefile to generate `.service` files from `.service.in` files via a pattern rule, to avoid duplicating the same command for each `.service` file.
