### PR TITLE
Update autogen.sh

### DIFF
--- a/autogen.sh
+++ b/autogen.sh
@@ -1,9 +1,9 @@
 #!/bin/sh
 
-autoreconf -f -i || exit
+autoreconf -fvi -I /usr/share/gettext/m4 || exit
 
 intltoolize -f || exit
 
 if [ -z "$NOCONFIGURE" ]; then
-	./configure --sysconfdir=/etc "$@"
+    ./configure --sysconfdir=/etc "$@"
 fi


### PR DESCRIPTION
fix compile issue on modern systems.

```text
[PC mpDris2]# ./autogen.sh --sysconfdir=/etc
configure.ac:21: warning: AM_NLS is m4_require'd but not m4_defun'd
aclocal.m4:26: IT_PROG_INTLTOOL is expanded from...
configure.ac:21: the top level
configure:3264: error: possibly undefined macro: AM_NLS
      If this token and others are legitimate, please use m4_pattern_allow.
      See the Autoconf documentation.
autoreconf: error: /usr/bin/autoconf failed with exit status: 1
```